### PR TITLE
Copy perfContentScript.js to build folder

### DIFF
--- a/build.py
+++ b/build.py
@@ -130,7 +130,7 @@ copyDirectoriesToBuild(['elements'], silentFail=False)
 # panel.js is a product of vulcanize. Since it got compiled to build/ we don't need it.
 removeFiles(['panel.js'], silentFail=False)
 
-copyFilesToBuild(['devtools.html', 'manifest.json'], silentFail=False)
+copyFilesToBuild(['devtools.html', 'manifest.json', 'perfContentScript.js'], silentFail=False)
 
 # <script>s are not copied by vulcanize, so these have to be moved in as well.
 execCmd('cp bower_components/platform/platform.js build/bower_components/platform/platform.js',


### PR DESCRIPTION
Closes #32

The extension fails to install in Chrome without perfContentScript.js in the build folder.
